### PR TITLE
feat: Add Slack reporting for packet analysis

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -46,6 +46,7 @@ jobs:
         contains(github.event.comment.body, '@gemini-cli') &&
         !contains(github.event.comment.body, '@gemini-cli /review') &&
         !contains(github.event.comment.body, '@gemini-cli /triage') &&
+        !contains(github.event.comment.body, '/send-report') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       ) ||
       (

--- a/.github/workflows/packet_copilot.yml
+++ b/.github/workflows/packet_copilot.yml
@@ -6,6 +6,17 @@ on:
     paths:
       - '**/*.pcap'
       - '**/*.pcapng'
+  workflow_call:
+    inputs:
+      slack_channel:
+        required: false
+        type: string
+      pcap_file:
+        required: false
+        type: string
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: false
 
 permissions:
   contents: write
@@ -30,7 +41,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${BEFORE}" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+          if [ -n "${{ inputs.pcap_file }}" ]; then
+            echo "${{ inputs.pcap_file }}" > /tmp/pcaps.txt
+          elif [ -z "${BEFORE}" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
             git ls-files '*.pcap' '*.pcapng' > /tmp/pcaps.txt || true
           else
             git diff --name-only "${BEFORE}" "${AFTER}" -- '*.pcap' '*.pcapng' > /tmp/pcaps.txt || true
@@ -151,6 +164,7 @@ jobs:
             ${{ env.ANALYSIS_DATA }}
 
       - name: 'Commit & push report'
+        if: "${{ !inputs.slack_channel }}"
         run: |
           set -euo pipefail
           report_path='${{ steps.prep.outputs.report_path }}'
@@ -163,3 +177,22 @@ jobs:
           else
             echo "No report produced for ${{ matrix.pcap }}"
           fi
+
+  send-to-slack:
+    needs: analyze-pcaps
+    if: "${{ inputs.slack_channel }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Read report'
+        id: read_report
+        run: |
+          report_content=$(cat ${{ needs.analyze-pcaps.outputs.report_path }})
+          echo "::set-output name=report::$report_content"
+
+      - name: Send to Slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel: ${{ inputs.slack_channel }}
+          text: "${{ steps.read_report.outputs.report }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/send-report.yml
+++ b/.github/workflows/send-report.yml
@@ -1,0 +1,26 @@
+
+name: '🚀 Send Report to Slack'
+
+on:
+  issue_comment:
+    types:
+      - 'created'
+
+jobs:
+  send_report:
+    if: "contains(github.event.comment.body, '/send-report')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Parse command'
+        id: parse
+        run: |
+          set -euo pipefail
+          body="${{ github.event.comment.body }}"
+          channel=$(echo "$body" | sed -n "s/.*\/send-report \([^ ]*\).*/\1/p")
+          echo "channel=${channel}" >> $GITHUB_OUTPUT
+
+      - name: 'Call Packet Copilot workflow'
+        uses: ./.github/workflows/packet_copilot.yml
+        with:
+          slack_channel: ${{ steps.parse.outputs.channel }}
+          pcap_file: 'capture.pcap'

--- a/conversation_with_matt_08142025/summary.md
+++ b/conversation_with_matt_08142025/summary.md
@@ -1,0 +1,9 @@
+I have created a new slash command, `/send-report`, that allows users to send a packet analysis report to a Slack channel of their choice.
+
+Here's a summary of the changes I've made:
+
+*   **Created a new GitHub Actions workflow** (`.github/workflows/send-report.yml`) that triggers on the `/send-report` command in an issue comment.
+*   **Modified the existing `packet_copilot.yml` workflow** to be callable by other workflows and to send the generated Markdown report to the specified Slack channel using a dummy secret.
+*   **Updated the `gemini-cli.yml` workflow** to ignore the new `/send-report` command.
+
+To use the new command, comment on any issue with `/send-report <your-channel-name>`. The bot will then analyze the `capture.pcap` file and post the report to the specified Slack channel.


### PR DESCRIPTION
This commit introduces a new slash command, `/send-report`, that allows users to send a packet analysis report to a Slack channel of their choice.

Changes include:
- A new GitHub Actions workflow (`send-report.yml`) to handle the slash command.
- Modifications to the `packet_copilot.yml` workflow to support Slack integration.
- Updates to `gemini-cli.yml` to ignore the new command.